### PR TITLE
JSONFunction / Slash escape / JDK 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.5</source>
+                    <target>1.5</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -53,7 +53,7 @@ public class JSONArray {
      * Creates a {@code JSONArray} with no values.
      */
     public JSONArray() {
-        values = new ArrayList<>();
+        values = new ArrayList<Object>();
     }
 
     /**
@@ -118,7 +118,7 @@ public class JSONArray {
             throw new JSONException("Not a primitive array: " + array.getClass());
         }
         final int length = Array.getLength(array);
-        values = new ArrayList<>(length);
+        values = new ArrayList<Object>(length);
         for (int i = 0; i < length; ++i) {
             put(JSONObject.wrap(Array.get(array, i)));
         }

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -122,7 +122,7 @@ public class JSONObject {
      * Creates a {@code JSONObject} with no name/value mappings.
      */
     public JSONObject() {
-        nameValuePairs = new LinkedHashMap<>();
+        nameValuePairs = new LinkedHashMap<String, Object>();
     }
 
     /**
@@ -792,7 +792,7 @@ public class JSONObject {
     public JSONArray names() {
         return nameValuePairs.isEmpty()
                 ? null
-                : new JSONArray(new ArrayList<>(nameValuePairs.keySet()));
+                : new JSONArray(new ArrayList<Object>(nameValuePairs.keySet()));
     }
 
     /**

--- a/src/test/java/org/json/JSONFunctionTestObject.java
+++ b/src/test/java/org/json/JSONFunctionTestObject.java
@@ -1,0 +1,19 @@
+package org.json;
+
+/**
+ * Class to test the function hack
+ */
+public class JSONFunctionTestObject
+{
+    private String value;
+
+    public JSONFunctionTestObject(String value)
+    {
+        this.value = value;
+    }
+
+    @Override
+    public String toString(){
+        return value;
+    }
+}

--- a/src/test/java/org/json/JSONObjectTest.java
+++ b/src/test/java/org/json/JSONObjectTest.java
@@ -31,7 +31,7 @@ public class JSONObjectTest {
     @Test
     public void testKeyset() throws Exception {
         JSONObject x = new JSONObject("{'a':1, 'b':2, 'c':3}");
-        Set<String> k = new TreeSet<>();
+        Set<String> k = new TreeSet<String>();
         for (String kx : Arrays.asList("a", "b", "c")) {
             k.add(kx);
         }
@@ -683,7 +683,7 @@ public class JSONObjectTest {
      */
     @Test
     public void testCreateWithUnsupportedNumbers() throws JSONException {
-        Map<String, Object> contents = new HashMap<>();
+        Map<String, Object> contents = new HashMap<String, Object>();
         contents.put("foo", Double.NaN);
         contents.put("bar", Double.NEGATIVE_INFINITY);
         contents.put("baz", Double.POSITIVE_INFINITY);
@@ -703,7 +703,7 @@ public class JSONObjectTest {
 
     @Test
     public void testMapConstructorCopiesContents() throws JSONException {
-        Map<String, Object> contents = new HashMap<>();
+        Map<String, Object> contents = new HashMap<String, Object>();
         contents.put("foo", 5);
         JSONObject object = new JSONObject(contents);
         contents.put("foo", 10);
@@ -712,7 +712,7 @@ public class JSONObjectTest {
 
     @Test
     public void testMapConstructorWithBogusEntries() {
-        Map<Object, Object> contents = new HashMap<>();
+        Map<Object, Object> contents = new HashMap<Object, Object>();
         contents.put(5, 5);
 
         try {
@@ -969,13 +969,13 @@ public class JSONObjectTest {
 
         @SuppressWarnings("unchecked")
         Iterator<String> keys = object.keys();
-        Set<String> result = new HashSet<>();
+        Set<String> result = new HashSet<String>();
         assertTrue(keys.hasNext());
         result.add(keys.next());
         assertTrue(keys.hasNext());
         result.add(keys.next());
         assertFalse(keys.hasNext());
-        assertEquals(new HashSet<>(Arrays.asList("foo", "bar")), result);
+        assertEquals(new HashSet<String>(Arrays.asList("foo", "bar")), result);
 
         try {
             keys.next();
@@ -1058,10 +1058,10 @@ public class JSONObjectTest {
     // https://code.google.com/p/android/issues/detail?id=55114
     @Test
     public void test_toString_listAsMapValue() throws Exception {
-        ArrayList<Object> list = new ArrayList<>();
+        ArrayList<Object> list = new ArrayList<Object>();
         list.add("a");
         list.add(new ArrayList<String>());
-        Map<String, Object> map = new TreeMap<>();
+        Map<String, Object> map = new TreeMap<String, Object>();
         map.put("x", "l");
         map.put("y", list);
         assertEquals("{\"x\":\"l\",\"y\":[\"a\",[]]}", new JSONObject(map).toString());

--- a/src/test/java/org/json/JSONStringerTest.java
+++ b/src/test/java/org/json/JSONStringerTest.java
@@ -26,6 +26,16 @@ import static org.junit.Assert.*;
 public class JSONStringerTest {
 
     @Test
+    public void testJSONFunctionHackTest(){
+        JSONStringer stringer = new JSONStringer();
+        stringer.object();
+        stringer.key("key");
+        stringer.value(new JSONFunctionTestObject("window.test()"));
+        stringer.endObject();
+        assertEquals("{\"key\":window.test()}", stringer.toString());
+    }
+
+    @Test
     public void testEmptyStringer() {
         // why isn't this the empty string?
         assertNull(new JSONStringer().toString());

--- a/src/test/java/org/json/JSONTokenerTest.java
+++ b/src/test/java/org/json/JSONTokenerTest.java
@@ -26,79 +26,79 @@ public class JSONTokenerTest extends TestCase {
 
     public void testNulls() throws JSONException {
         // JSONTokener accepts null, only to fail later on almost all APIs!
-        new JSONTokener(null).back();
+        new JSONTokener((String)null).back();
 
         try {
-            new JSONTokener(null).more();
+            new JSONTokener((String)null).more();
             fail();
         } catch (NullPointerException ignored) {
         }
 
         try {
-            new JSONTokener(null).next();
+            new JSONTokener((String)null).next();
             fail();
         } catch (NullPointerException ignored) {
         }
 
         try {
-            new JSONTokener(null).next(3);
+            new JSONTokener((String)null).next(3);
             fail();
         } catch (NullPointerException ignored) {
         }
 
         try {
-            new JSONTokener(null).next('A');
+            new JSONTokener((String)null).next('A');
             fail();
         } catch (NullPointerException ignored) {
         }
 
         try {
-            new JSONTokener(null).nextClean();
+            new JSONTokener((String)null).nextClean();
             fail();
         } catch (NullPointerException ignored) {
         }
 
         try {
-            new JSONTokener(null).nextString('"');
+            new JSONTokener((String)null).nextString('"');
             fail();
         } catch (NullPointerException ignored) {
         }
 
         try {
-            new JSONTokener(null).nextTo('A');
+            new JSONTokener((String)null).nextTo('A');
             fail();
         } catch (NullPointerException ignored) {
         }
 
         try {
-            new JSONTokener(null).nextTo("ABC");
+            new JSONTokener((String)null).nextTo("ABC");
             fail();
         } catch (NullPointerException ignored) {
         }
 
         try {
-            new JSONTokener(null).nextValue();
+            new JSONTokener((String)null).nextValue();
             fail();
         } catch (NullPointerException ignored) {
         }
 
         try {
-            new JSONTokener(null).skipPast("ABC");
+            new JSONTokener((String)null).skipPast("ABC");
             fail();
         } catch (NullPointerException ignored) {
         }
 
         try {
-            new JSONTokener(null).skipTo('A');
+            new JSONTokener((String)null).skipTo('A');
             fail();
         } catch (NullPointerException ignored) {
         }
 
         //noinspection ThrowableResultOfMethodCallIgnored
         assertEquals("foo! at character 0 of null",
-                new JSONTokener(null).syntaxError("foo!").getMessage());
+                new JSONTokener((String)null).syntaxError("foo!").getMessage());
 
-        assertEquals(" at character 0 of null", new JSONTokener(null).toString());
+        assertEquals(" at character 0 of null", new JSONTokener((String)null).toString());
     }
 
     public void testEmptyString() throws JSONException {

--- a/src/test/java/org/json/ParsingTest.java
+++ b/src/test/java/org/json/ParsingTest.java
@@ -146,7 +146,7 @@ public class ParsingTest {
         // the value -1 expressed as unsigned hex if you use the normal JDK. Presumably
         // the Android equivalent program does this better.
         assertParsed("Large hex longs shouldn't yield ints or strings",
-                0xFFF_FFFF_FFFF_FFFFL, "0xFFFFFFFFFFFFFFF");
+                0xFFFFFFFFFFFFFFFL, "0xFFFFFFFFFFFFFFF");
     }
 
     @Test
@@ -272,14 +272,14 @@ public class ParsingTest {
     private Object canonicalize(Object input) throws JSONException {
         if (input instanceof JSONArray) {
             JSONArray array = (JSONArray) input;
-            List<Object> result = new ArrayList<>();
+            List<Object> result = new ArrayList<Object>();
             for (int i = 0; i < array.length(); i++) {
                 result.add(canonicalize(array.opt(i)));
             }
             return result;
         } else if (input instanceof JSONObject) {
             JSONObject object = (JSONObject) input;
-            Map<String, Object> result = new HashMap<>();
+            Map<String, Object> result = new HashMap<String,Object>();
             for (Iterator<?> i = object.keys(); i.hasNext(); ) {
                 String key = (String) i.next();
                 result.put(key, canonicalize(object.get(key)));


### PR DESCRIPTION
* JSONFunction class for value as a hack to not surround it with quotes
* Only escape "/" slash after a "<" bracket, because it is allowed
* JDK 1.5