### PR TITLE
Each JSONObject constructor should only throw runtime exceptions

### DIFF
--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -207,19 +207,32 @@ public class JSONObject {
         }
     }
 
-    public JSONObject(Object bean) throws IntrospectionException, InvocationTargetException, IllegalAccessException {
+    /**
+     * Creates a json object from a bean
+     * @param bean the bean to create the json object from
+     * @throws JSONException If there is an exception while reading the bean
+     */
+    public JSONObject(Object bean) throws JSONException {
         this(propertiesAsMap(bean));
     }
 
     private static Map<String, Object> propertiesAsMap(Object bean)
-            throws IntrospectionException, IllegalAccessException, InvocationTargetException {
-        PropertyDescriptor[] properties = Introspector.getBeanInfo(bean.getClass(), Object.class)
-                .getPropertyDescriptors();
-        Map<String, Object> props = new TreeMap<String, Object>();
-        for (PropertyDescriptor prop : properties) {
-            Object v = prop.getReadMethod().invoke(bean);
-            props.put(prop.getDisplayName(), wrap(v));
-        }
+            throws JSONException {
+    	Map<String, Object> props = new TreeMap<String, Object>();
+	    	try{  
+	        PropertyDescriptor[] properties = Introspector.getBeanInfo(bean.getClass(), Object.class)
+	                .getPropertyDescriptors();
+	        for (PropertyDescriptor prop : properties) {
+	            Object v = prop.getReadMethod().invoke(bean);
+	            props.put(prop.getDisplayName(), wrap(v));
+	        }
+    	}catch( IllegalAccessException e){
+    		throw new JSONException(e);
+    	}catch(IntrospectionException e){
+    		throw new JSONException(e);
+    	}catch(InvocationTargetException e){
+    		throw new JSONException(e);    		
+    	}
         return props;
     }
 


### PR DESCRIPTION
Hi @tdunning ,

@bitstorm mentioned a good point we noticed during some code testings against the original json.org and the open-json implementation:

* see https://github.com/apache/wicket/pull/195#issuecomment-270600508

According to the API of json.org every constructor only throws runtime exceptions. If we change that behavior the user is required to catch those.

I think it would be better both implementation behave the same way.

Because Apache Wicket 8.0 is going to be released soon it would be great if you could release version 1.8 (with this change) so that we only have to change the dependency for the release.

Thank you so much for you time!