### PR TITLE
Speed up serialization of String values in JSONObject

### DIFF
--- a/src/main/java/org/json/JSONStringer.java
+++ b/src/main/java/org/json/JSONStringer.java
@@ -260,6 +260,9 @@ public class JSONStringer {
         } else if (value instanceof Number) {
             out.append(JSONObject.numberToString((Number) value));
 
+        } else if (value instanceof String) {
+            string((String) value);
+
         } else {
             // Hack to make it possible that the value is not surrounded by quotes. (Used for JavaScript function calls)
             // Example: { "name": "testkey", "value": window.myfunction() }


### PR DESCRIPTION
When a JSONObject which holds String objects as values is serialized, for every object value is the class name is checked whether it contains "JSONFunc" (see #1 resp. 174ab93). Handling this common case beforehand speeds up the serialization of JSON objects holding simple string maps:
- 20-30% faster with this trivial benchmark:
```
	public void benchmarkStringMap() {
		// benchmark serialization of an object holding a simple String-to-String map
		int iterations = 20;
		int size = 50000;
		long elapsed = 0;
		int length = 0;
		for (int i = 0; i < iterations; i++) {
			JSONObject x = new JSONObject();
			for (int j = 0; j < size; j++) {
				x.put("key" + j + i, "val" + j + i);
			}
			long start = System.currentTimeMillis();
			length += x.toString().length();
			elapsed += (System.currentTimeMillis() - start);
		}
		System.out.println("Benchmark\n elapsed: " + elapsed + " ms");
		System.out.println(" output length: " + length);
	}
```
- see also profiler screenshots in [commoncrawl/ia-web-commons#16](https://github.com/commoncrawl/ia-web-commons/pull/16#issuecomment-513818568)
